### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -53,8 +53,11 @@ class MaxEngine(tank.platform.Engine):
             # specifically for 2013 which is not officially supported but may work, output a warning:
             self.log_warning("This version of 3ds Max is not officially supported by Toolkit and you may "
                              "experience instability.  Please contact support@shotgunsoftware.com "
-                             "if you do have any issues.")        
-        
+                             "if you do have any issues.")
+
+        max_ver_str = ".".join([str(v) for v in mxs.maxVersion()])
+        self.log_user_attribute_metric("3ds Max version", max_ver_str)
+
         # set up a qt style sheet
         # note! - try to be smart about this and only run
         # the style setup once per session - it looks like

--- a/engine.py
+++ b/engine.py
@@ -13,6 +13,7 @@ A 3ds Max engine for Tank.
 
 """
 
+import math
 import os
 import sys
 import time
@@ -56,8 +57,10 @@ class MaxEngine(tank.platform.Engine):
                              "if you do have any issues.")
 
         try:
-            max_ver_str = ".".join([str(v) for v in mxs.maxVersion()])
-            self.log_user_attribute_metric("3ds Max version", max_ver_str)
+            # translate the max version into a year. this line was pulled from
+            # the 3dsmaxplus engine's _max_version_to_ear() method.
+            ver_year = int(2000 + (math.ceil(mxs.maxVersion() / 1000.0) - 2))
+            self.log_user_attribute_metric("3ds Max version", ver_year)
         except:
             # ignore all errors. ex: using a core that doesn't support metrics
             pass

--- a/engine.py
+++ b/engine.py
@@ -55,8 +55,12 @@ class MaxEngine(tank.platform.Engine):
                              "experience instability.  Please contact support@shotgunsoftware.com "
                              "if you do have any issues.")
 
-        max_ver_str = ".".join([str(v) for v in mxs.maxVersion()])
-        self.log_user_attribute_metric("3ds Max version", max_ver_str)
+        try:
+            max_ver_str = ".".join([str(v) for v in mxs.maxVersion()])
+            self.log_user_attribute_metric("3ds Max version", max_ver_str)
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
         # set up a qt style sheet
         # note! - try to be smart about this and only run

--- a/info.yml
+++ b/info.yml
@@ -30,6 +30,3 @@ description: "Shotgun Integration in 3ds Max"
 requires_shotgun_version:
 requires_core_version: "v0.14.61"
 
-# XXX will require core version with metrics logging
-
-

--- a/info.yml
+++ b/info.yml
@@ -30,3 +30,6 @@ description: "Shotgun Integration in 3ds Max"
 requires_shotgun_version:
 requires_core_version: "v0.14.61"
 
+# XXX will require core version with metrics logging
+
+


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.