### PR TITLE
SG-14434: PyMXS port

### DIFF
--- a/hooks/tk-multi-loader2/basic/scene_actions.py
+++ b/hooks/tk-multi-loader2/basic/scene_actions.py
@@ -185,7 +185,7 @@ class MaxActions(HookBaseClass):
         # The fix for that would be to set AlembicImport.ZUp to false
         # via maxscript prior to running the importFile.
         self.parent.engine.safe_dialog_exec(
-            lambda: _execute_script('importFile @"%s" #noPrompt' % path)
+            lambda: pymxs.runtime.execute('importFile @"%s" #noPrompt' % path)
         )
 
     def _merge(self, path, sg_publish_data):

--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -234,7 +234,7 @@ class MaxSessionGeometryPublishPlugin(HookBaseClass):
                 'exportFile @"%s" #noPrompt using:AlembicExport' % publish_path
             )
             self.parent.log_debug("Executing command: %s" % abc_export_cmd)
-            _execute_script(abc_export_cmd)
+            pymxs.runtime.execute(abc_export_cmd)
         except Exception as e:
             raise Exception("Failed to export Alembic Cache: %s" % e)
 
@@ -256,10 +256,6 @@ def _session_path():
 
 def _is_empty_scene():
     return len(pymxs.runtime.rootNode.Children) == 0
-
-
-def _execute_script(script):
-    pymxs.runtime.execute(script)
 
 
 def _get_save_as_action():

--- a/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
+++ b/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
@@ -152,7 +152,7 @@ class MaxActions(HookBaseClass):
         # The fix for that would be to set AlembicImport.ZUp to false
         # via maxscript prior to running the importFile.
         self.parent.engine.safe_dialog_exec(
-            lambda: _execute_script('importFile @"%s" #noPrompt' % path)
+            lambda: pymxs.runtime.execute('importFile @"%s" #noPrompt' % path)
         )
 
     def _merge(self, path, sg_publish_data):


### PR DESCRIPTION
Fixed references to unknown methods. I replaced the call to the missing method by the call to the actual method that should be called, `pymxs.run.execute_script`.