### PR TITLE
Fixing dependency error at hooks/tk-multi-workfiles2/basic/scene_operation.py

### DIFF
--- a/hooks/tk-multi-workfiles2/basic/scene_operation.py
+++ b/hooks/tk-multi-workfiles2/basic/scene_operation.py
@@ -8,6 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import os
+
 import pymxs
 
 import sgtk


### PR DESCRIPTION
Fixed a dependency import at ´hooks/tk-multi-workfiles2/basic/scene_operation.py´ which caused File saving names to be reverted to the default "scene" value even when a previous file already existed.