### PR TITLE
SG-42790 support for 3dsmax 2027

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -37,6 +37,6 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
     - id: black

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for 3ds Max
 
-![Supported 3ds Max versions: 2023 - 2026](https://img.shields.io/badge/3ds%20Max-2023_--_2026-blue?logo=autodesk "Supported 3ds Max versions")
-[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
-[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
+![Supported 3ds Max versions: 2024 - 2027](https://img.shields.io/badge/3ds%20Max-2023_--_2026-blue?logo=autodesk "Supported 3ds Max versions")
+[![Supported VFX Platform: CY2022 - CY2026](https://img.shields.io/badge/VFX_Reference_Platform-CY2022_|_CY2023_|_CY2024_|_CY2025_|_CY2026-blue)](http://www.vfxplatform.com/ "Supported VFX Reference Platform versions")
+[![Supported Python versions: 3.9, 3.10, 3.11, 3.13](https://img.shields.io/badge/Python-3.9_|_3.10_|_3.11_|_3.13-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/engine.py
+++ b/engine.py
@@ -10,6 +10,7 @@
 """
 A 3ds Max (2022+) engine for Toolkit based pymxs
 """
+
 import os
 import math
 import sgtk

--- a/engine.py
+++ b/engine.py
@@ -17,9 +17,9 @@ import sgtk
 import pymxs
 
 # Max versions compatibility constants
-VERSION_OLDEST_COMPATIBLE = 2021
-VERSION_OLDEST_SUPPORTED = 2023
-VERSION_NEWEST_SUPPORTED = 2026
+VERSION_OLDEST_COMPATIBLE = 2022
+VERSION_OLDEST_SUPPORTED = 2024
+VERSION_NEWEST_SUPPORTED = 2027
 # Caution: make sure compatibility_dialog_min_version default value in info.yml
 # is equal to VERSION_NEWEST_SUPPORTED
 

--- a/hooks/tk-multi-loader2/basic/scene_actions.py
+++ b/hooks/tk-multi-loader2/basic/scene_actions.py
@@ -11,6 +11,7 @@
 """
 Hook that loads defines all the available actions, broken down by publish type.
 """
+
 import sgtk
 import os
 
@@ -195,7 +196,7 @@ class MaxActions(HookBaseClass):
         if not os.path.exists(path):
             raise Exception("File not found on disk - '%s'" % path)
 
-        (_, ext) = os.path.splitext(path)
+        _, ext = os.path.splitext(path)
 
         supported_file_exts = [".max"]
         if ext.lower() not in supported_file_exts:
@@ -223,7 +224,7 @@ class MaxActions(HookBaseClass):
         if not os.path.exists(path):
             raise Exception("File not found on disk - '%s'" % path)
 
-        (_, ext) = os.path.splitext(path)
+        _, ext = os.path.splitext(path)
 
         supported_file_exts = [".max"]
         if ext.lower() not in supported_file_exts:

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -14,7 +14,6 @@ from sgtk.platform.qt import QtGui
 
 import pymxs
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -86,9 +86,7 @@ class MaxSessionPublishPlugin(HookBaseClass):
         however only the most recent publish will be available to other users.
         Warnings will be provided during validation if there are previous
         publishes.
-        """ % (
-            loader_url,
-        )
+        """ % (loader_url,)
 
     @property
     def settings(self):
@@ -247,13 +245,13 @@ class MaxSessionPublishPlugin(HookBaseClass):
         # check to see if the next version of the work file already exists on
         # disk. if so, warn the user and provide the ability to jump to save
         # to that version now
-        (next_version_path, version) = self._get_next_version_info(path, item)
+        next_version_path, version = self._get_next_version_info(path, item)
         if next_version_path and os.path.exists(next_version_path):
 
             # determine the next available version_number. just keep asking for
             # the next one until we get one that doesn't exist.
             while os.path.exists(next_version_path):
-                (next_version_path, version) = self._get_next_version_info(
+                next_version_path, version = self._get_next_version_info(
                     next_version_path, item
                 )
 

--- a/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
+++ b/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
@@ -13,7 +13,6 @@ import sgtk
 
 import pymxs
 
-
 HookBaseClass = sgtk.get_hook_baseclass()
 
 
@@ -168,7 +167,7 @@ class MaxActions(HookBaseClass):
         if not os.path.exists(path):
             raise Exception("File not found on disk - '%s'" % path)
 
-        (_, ext) = os.path.splitext(path)
+        _, ext = os.path.splitext(path)
 
         supported_file_exts = [".max"]
         if ext.lower() not in supported_file_exts:
@@ -196,7 +195,7 @@ class MaxActions(HookBaseClass):
         if not os.path.exists(path):
             raise Exception("File not found on disk - '%s'" % path)
 
-        (_, ext) = os.path.splitext(path)
+        _, ext = os.path.splitext(path)
 
         supported_file_exts = [".max"]
         if ext.lower() not in supported_file_exts:

--- a/info.yml
+++ b/info.yml
@@ -54,7 +54,7 @@ configuration:
                         it isn't yet fully supported and tested with Toolkit.  To disable the warning
                         dialog for the version you are testing, it is recommended that you set this
                         value to the current major version + 1."
-        default_value: 2026
+        default_value: 2027
 
     launch_builtin_plugins:
         type: list

--- a/python/tk_3dsmax/maxscript.py
+++ b/python/tk_3dsmax/maxscript.py
@@ -11,6 +11,7 @@
 """
 MaxScript handling for 3ds Max
 """
+
 import hashlib
 import sgtk
 
@@ -52,14 +53,10 @@ class MaxScript:
         MaxScript.unregister_menu("Shotgun")
 
         MaxScript.unregister_menu(menu_name)
-        pymxs.runtime.execute(
-            """
+        pymxs.runtime.execute("""
             -- create the main menu
             {menu_var} = menuMan.createMenu "{menu_name}"
-        """.format(
-                menu_var=menu_var, menu_name=menu_name
-            )
-        )
+        """.format(menu_var=menu_var, menu_name=menu_name))
 
     @staticmethod
     def unregister_menu(menu_name):
@@ -68,15 +65,11 @@ class MaxScript:
 
         :param str menu_name: Name of the menu in the menu bar.
         """
-        pymxs.runtime.execute(
-            """
+        pymxs.runtime.execute("""
             -- clear the menu
             sgtk_oldMenu = menuMan.findMenu "{menu_name}"
             if sgtk_oldMenu != undefined then menuMan.unregisterMenu sgtk_oldMenu
-        """.format(
-                menu_name=menu_name
-            )
-        )
+        """.format(menu_name=menu_name))
 
     @staticmethod
     def add_separator(menu_var):
@@ -85,14 +78,10 @@ class MaxScript:
         :param menu_var: MaxScript variable name of the menu to add separator into
         """
 
-        pymxs.runtime.execute(
-            """
+        pymxs.runtime.execute("""
             sgtk_menu_separator = menuMan.createSeparatorItem()
             {menu_var}.addItem sgtk_menu_separator -1
-        """.format(
-                menu_var=menu_var
-            )
-        )
+        """.format(menu_var=menu_var))
 
     @staticmethod
     def add_to_main_menu_bar(menu_var, menu_name):
@@ -102,18 +91,14 @@ class MaxScript:
         :param menu_name: String name of the menu to add
         """
 
-        pymxs.runtime.execute(
-            """
+        pymxs.runtime.execute("""
             -- Add main menu to Max, second to last which should be before Help
             sgtk_main_menu_bar = menuMan.getMainMenuBar()
             sgtk_sub_menu_index = sgtk_main_menu_bar.numItems() - 1
             sgtk_sub_menu_item = menuMan.createSubMenuItem "{menu_name}" {menu_var}
             sgtk_main_menu_bar.addItem sgtk_sub_menu_item sgtk_sub_menu_index
             menuMan.updateMenuBar()
-        """.format(
-                menu_var=menu_var, menu_name=menu_name
-            )
-        )
+        """.format(menu_var=menu_var, menu_name=menu_name))
 
     @staticmethod
     def add_action_to_menu(callback, action_name, menu_var, engine):

--- a/python/tk_3dsmax/menu_generation_callbacks.py
+++ b/python/tk_3dsmax/menu_generation_callbacks.py
@@ -11,6 +11,7 @@
 """
 Menu handling for 3ds Max
 """
+
 from pymxs import runtime as rt
 
 from .menu_generation_menuman import MenuGenerator_menuMan, AppCommand
@@ -144,9 +145,7 @@ class MenuGenerator_callbacks(MenuGenerator_menuMan):
                 menu_item_selected id
             )
         )
-        """.format(
-            context_name=str(self._engine.context)
-        )
+        """.format(context_name=str(self._engine.context))
         rt.execute(mxswrapper)
 
         def create_menu_callback():

--- a/python/tk_3dsmax/menu_generation_menuman.py
+++ b/python/tk_3dsmax/menu_generation_menuman.py
@@ -11,6 +11,7 @@
 """
 Menu handling for 3ds Max
 """
+
 import os
 import sys
 import traceback

--- a/startup.py
+++ b/startup.py
@@ -16,7 +16,7 @@ import sgtk
 from sgtk.platform import SoftwareLauncher, SoftwareVersion, LaunchInformation
 
 # Max versions compatibility constants
-VERSION_OLDEST_COMPATIBLE = 2021
+VERSION_OLDEST_COMPATIBLE = 2022
 
 
 class MaxLauncher(SoftwareLauncher):
@@ -48,7 +48,7 @@ class MaxLauncher(SoftwareLauncher):
 
         supported_sw_versions = []
         for sw_version in self._find_software():
-            (supported, reason) = self._is_supported(sw_version)
+            supported, reason = self._is_supported(sw_version)
             if supported:
                 supported_sw_versions.append(sw_version)
             else:


### PR DESCRIPTION
This pull request updates the compatibility and support information for 3ds Max, Python, and the VFX Reference Platform to reflect support for newer versions. The changes ensure that both the documentation and the engine configuration are aligned with the latest supported software versions.

**Updated version support:**

* Updated the supported 3ds Max versions in the `README.md` badge and in the constants in `engine.py` to include up to 2027, and set the oldest supported version to 2024. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R5) [[2]](diffhunk://#diff-773b7e340b77c3c54109da863b41163ac971f899da59d8efcbfba7ce8a9c7e88L20-R22)
* Updated the VFX Reference Platform badge in `README.md` to list CY2022 through CY2026, reflecting a broader and more current range.
* Updated the supported Python versions in the `README.md` badge to include 3.13.

**Configuration alignment:**

* Changed the `default_value` for `compatibility_dialog_min_version` in `info.yml` to 2027, matching the new `VERSION_NEWEST_SUPPORTED`.